### PR TITLE
Fixed issue [security] #20384: XSS Vulnerability in question editor

### DIFF
--- a/application/extensions/AdvancedSettingWidget/views/textarea.php
+++ b/application/extensions/AdvancedSettingWidget/views/textarea.php
@@ -14,7 +14,7 @@
                     id="<?= CHtml::getIdByName($inputBaseName . "[" . $lang ."]"); ?>"
                     aria-labelledby="label-<?= CHtml::getIdByName($inputBaseName); ?>"
                     <?= ($this->setting['help']) ? 'aria-describedby="help-' . CHtml::getIdByName($inputBaseName) . '"' : "" ?>
-                    ><?= $this->setting[$lang]['value']; ?></textarea>
+                    ><?= CHtml::encode($this->setting[$lang]['value']); ?></textarea>
             </div>
         <?php endforeach; ?>
     <?php else: ?>
@@ -23,7 +23,7 @@
             name="<?= $inputBaseName ?>"
             id="<?= CHtml::getIdByName($inputBaseName); ?>"
             <?= ($this->setting['help']) ? 'aria-describedby="help-' . CHtml::getIdByName($inputBaseName) . '"' : "" ?>
-            ><?= $this->setting['value']; ?></textarea>
+            ><?= CHtml::encode($this->setting['value']); ?></textarea>
         <?php endif; ?>
     <?php if (isset($this->setting['aFormElementOptions']['inputGroup']['suffix'])) : ?>
         <div class="input-group-addon">

--- a/application/extensions/GeneralOptionWidget/views/textarea.php
+++ b/application/extensions/GeneralOptionWidget/views/textarea.php
@@ -9,7 +9,7 @@
         name="question[<?= $this->generalOption->name; ?>]" 
         id="<?= CHtml::getIdByName($this->generalOption->name); ?>"
         <?= ($this->generalOption->formElement->help) ? 'aria-describedby="help-' . CHtml::getIdByName($this->generalOption->name) . '"' : "" ?>
-        ><?= $this->generalOption->formElement->value; ?></textarea>
+        ><?= CHtml::encode($this->generalOption->formElement->value); ?></textarea>
     <?php if (isset($this->generalOption->formElement->options['inputGroup']['suffix'])) : ?>
         <div class="input-group-addon">
             <?= $this->generalOption->formElement->options['inputGroup']['suffix']; ?>


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Prevent XSS vulnerability by encoding textarea values

- Apply HTML encoding to three textarea output locations

- Use CHtml::encode() for user-controlled content display


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Textarea Value Output"] -->|Add CHtml::encode| B["HTML-Encoded Output"]
  B -->|Prevents XSS| C["Secure Display"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>textarea.php</strong><dd><code>Encode textarea values in AdvancedSettingWidget</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/extensions/AdvancedSettingWidget/views/textarea.php

<ul><li>Wrapped <code>$this->setting[$lang]['value']</code> with <code>CHtml::encode()</code> in <br>multi-language textarea<br> <li> Wrapped <code>$this->setting['value']</code> with <code>CHtml::encode()</code> in <br>single-language textarea<br> <li> Prevents XSS attacks by escaping HTML special characters in textarea <br>content</ul>


</details>


  </td>
  <td><a href="https://github.com/SondagesPro/LimeSurvey-SondagesPro/pull/18/files#diff-5b57f674e9ead25bac912e0077c392e3c1a5d9fb8d5b5f9b467cc4340f1b224b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>textarea.php</strong><dd><code>Encode textarea value in GeneralOptionWidget</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

application/extensions/GeneralOptionWidget/views/textarea.php

<ul><li>Wrapped <code>$this->generalOption->formElement->value</code> with <code>CHtml::encode()</code><br> <li> Prevents XSS attacks by escaping HTML special characters in textarea <br>content</ul>


</details>


  </td>
  <td><a href="https://github.com/SondagesPro/LimeSurvey-SondagesPro/pull/18/files#diff-53fbe00cb2cb2ec4cff7e69707c60e4908c58662496aa0c6ea5d3f3a6326b225">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

