### PR TITLE
Fixed issue #20458: [security] Unsafe php unserialize calls on attachements attribute (reported by podalirius )

### DIFF
--- a/application/config/config-defaults.php
+++ b/application/config/config-defaults.php
@@ -844,5 +844,11 @@ $config['passwordValidationRules'] = array(
 // @see https://www.php.net/unserialize
 $config['allow_unserialize_attributedescriptions'] = false;
 
+// Allow unserializing (with PHP unserialize function) attachments attributes when importing survey
+// In limesurvey 6.16.17 and SondagesPro version 5.6.87 : attachments attribute move from serialize to json_encode. If you need to keep attachment when import, you have to allow it
+// Warning: Unserialization can result in code being loaded and executed due to object instantiation and autoloading, and a malicious user may be able to exploit this.
+// @see https://www.php.net/unserialize
+$config['allow_unserialize_attachments'] = false;
+
 return $config;
 //settings deleted

--- a/application/config/version.php
+++ b/application/config/version.php
@@ -12,7 +12,7 @@
  */
 
 $config['versionnumber'] = '5.6.86 (SondagesPro)';
-$config['dbversionnumber'] = 499;
+$config['dbversionnumber'] = 500;
 $config['buildnumber'] = '';
 $config['updatable'] = false;
 $config['templateapiversion']  = 3;

--- a/application/controllers/admin/EmailTemplates.php
+++ b/application/controllers/admin/EmailTemplates.php
@@ -49,9 +49,7 @@ class EmailTemplates extends SurveyCommonAction
             $ishtml = false;
         }
 
-        $grplangs = Survey::model()->findByPk($iSurveyId)->additionalLanguages;
-        $baselang = Survey::model()->findByPk($iSurveyId)->language;
-        array_unshift($grplangs, $baselang);
+        $grplangs = Survey::model()->findByPk($iSurveyId)->getAllLanguages();
 
         $sEditScript = PrepareEditorScript(false, $this->getController());
         $aData['attrib'] = array();
@@ -64,20 +62,19 @@ class EmailTemplates extends SurveyCommonAction
         }
         $uploadDir = realpath(Yii::app()->getConfig('uploaddir'));
         foreach ($grplangs as $key => $grouplang) {
+            $SurveyLanguageSetting = SurveyLanguageSetting::model()->findByPk(['surveyls_survey_id' => $iSurveyId, 'surveyls_language' => $grouplang]);
             $aData['bplangs'][$key] = $grouplang;
-            $aData['attrib'][$key] = SurveyLanguageSetting::model()->find('surveyls_survey_id = :ssid AND surveyls_language = :ls', array(':ssid' => $iSurveyId, ':ls' => $grouplang));
-            $attachments = unserialize($aData['attrib'][$key]['attachments']);
-            if (is_array($attachments)) {
-                foreach ($attachments as &$template) {
-                    foreach ($template as &$attachment) {
-                        // If the file is missing we add an error message
-                        if (!$this->attachmentExists($iSurveyId, $attachment)) {
-                            $attachment['error'] = gT("File not found.");
-                        }
-                        // For security reasons we don't include the full upload path in the frontend
-                        if (substr($attachment['url'], 0, strlen($uploadDir)) == $uploadDir) {
-                            $attachment['url'] = str_replace('\\', '/', substr($attachment['url'], strlen($uploadDir)));
-                        }
+            $aData['attrib'][$key] = $SurveyLanguageSetting;
+            $attachments = $SurveyLanguageSetting->getValidAttachments(false);
+            foreach ($attachments as &$template) {
+                foreach ($template as &$attachment) {
+                    // If the file is missing we add an error message
+                    if (!$SurveyLanguageSetting->getAttachmentFileExist($attachment['url'])) {
+                        $attachment['error'] = gT("File not found.");
+                    }
+                    // For security reasons we don't include the full upload path in the frontend
+                    if (substr((string) $attachment['url'], 0, strlen($uploadDir)) == $uploadDir) {
+                        $attachment['url'] = str_replace('\\', '/', substr((string) $attachment['url'], strlen($uploadDir)));
                     }
                 }
             }
@@ -124,47 +121,40 @@ class EmailTemplates extends SurveyCommonAction
         // We need the real path since we check that the resolved file name starts with this path.
         $uploadDir = realpath(Yii::app()->getConfig('uploaddir'));
         $sSaveMethod = Yii::app()->request->getPost('save', '');
+        $attachementsPost = App()->getRequest()->getPost('attachments', []);
         if (Permission::model()->hasSurveyPermission($iSurveyId, 'surveylocale', 'update') && $sSaveMethod != '') {
-            $languagelist = Survey::model()->findByPk($iSurveyId)->additionalLanguages;
-            $languagelist[] = Survey::model()->findByPk($iSurveyId)->language;
-            array_filter($languagelist);
+            $languagelist = Survey::model()->findByPk($iSurveyId)->getAllLanguages();
             foreach ($languagelist as $langname) {
-                if (isset($_POST['attachments'][$langname])) {
-                    foreach ($_POST['attachments'][$langname] as $template => &$attachments) {
-                        foreach ($attachments as $index => &$attachment) {
-                            // We again take the real path.
-                            $localName = realpath(urldecode($uploadDir . str_replace($uploadUrl, '', $attachment['url'])));
+                $attachementsLang = [];
+                if (isset($attachementsPost[$langname])) {
+                    foreach ($attachementsPost[$langname] as $template => $attachments) {
+                        foreach ($attachments as $attachment) {
+                            $localName = realpath(urldecode($uploadDir . str_replace($uploadUrl, '', (string) $attachment['url'])));
                             if ($localName !== false) {
                                 if (strpos($localName, $uploadDir) === 0) {
                                     $attachment['url'] = $localName;
                                     $attachment['size'] = filesize($localName);
-                                } else {
-                                    unset($attachments[$index]);
+                                    $attachementsLang[$template][] = $attachment;
                                 }
-                            } else {
-                                unset($attachments[$index]);
                             }
                         }
-                        unset($attachments);
                     }
-                } else {
-                    $_POST['attachments'][$langname] = array();
                 }
 
                 $attributes = array(
-                    'surveyls_email_invite_subj' => $_POST['email_invitation_subj_' . $langname],
-                    'surveyls_email_invite' => $_POST['email_invitation_' . $langname],
-                    'surveyls_email_remind_subj' => $_POST['email_reminder_subj_' . $langname],
-                    'surveyls_email_remind' => $_POST['email_reminder_' . $langname],
-                    'surveyls_email_register_subj' => $_POST['email_registration_subj_' . $langname],
-                    'surveyls_email_register' => $_POST['email_registration_' . $langname],
-                    'surveyls_email_confirm_subj' => $_POST['email_confirmation_subj_' . $langname],
-                    'surveyls_email_confirm' => $_POST['email_confirmation_' . $langname],
-                    'email_admin_notification_subj' => $_POST['email_admin_notification_subj_' . $langname],
-                    'email_admin_notification' => $_POST['email_admin_notification_' . $langname],
-                    'email_admin_responses_subj' => $_POST['email_admin_detailed_notification_subj_' . $langname],
-                    'email_admin_responses' => $_POST['email_admin_detailed_notification_' . $langname],
-                    'attachments' => serialize($_POST['attachments'][$langname])
+                    'surveyls_email_invite_subj' => App()->getRequest()->getPost('email_invitation_subj_' . $langname),
+                    'surveyls_email_invite' => App()->getRequest()->getPost('email_invitation_' . $langname),
+                    'surveyls_email_remind_subj' => App()->getRequest()->getPost('email_reminder_subj_' . $langname),
+                    'surveyls_email_remind' => App()->getRequest()->getPost('email_reminder_' . $langname),
+                    'surveyls_email_register_subj' => App()->getRequest()->getPost('email_registration_subj_' . $langname),
+                    'surveyls_email_register' => App()->getRequest()->getPost('email_registration_' . $langname),
+                    'surveyls_email_confirm_subj' => App()->getRequest()->getPost('email_confirmation_subj_' . $langname),
+                    'surveyls_email_confirm' => App()->getRequest()->getPost('email_confirmation_' . $langname),
+                    'email_admin_notification_subj' => App()->getRequest()->getPost('email_admin_notification_subj_' . $langname),
+                    'email_admin_notification' => App()->getRequest()->getPost('email_admin_notification_' . $langname),
+                    'email_admin_responses_subj' => App()->getRequest()->getPost('email_admin_detailed_notification_subj_' . $langname),
+                    'email_admin_responses' => App()->getRequest()->getPost('email_admin_detailed_notification_' . $langname),
+                    'attachments' => json_encode($attachementsLang)
                 );
 
                 $aLanguageSetting = SurveyLanguageSetting::model()->find('surveyls_survey_id = :ssid AND surveyls_language = :sl', array(':ssid' => $iSurveyId, ':sl' => $langname));
@@ -323,31 +313,5 @@ class EmailTemplates extends SurveyCommonAction
         App()->getClientScript()->registerPackage('emailtemplates');
         $aData['display']['menu_bars']['surveysummary'] = 'editemailtemplates';
         parent::renderWrappedTemplate($sAction, $aViewUrls, $aData, $sRenderFile);
-    }
-
-    /**
-     * Checks that the specified attachment exists on one of the allowed paths.
-     * @param array<string,mixed> The attachment data
-     * @return bool True if the file exists within the survey or global upload dirs.
-     */
-    private function attachmentExists($surveyId, $attachment)
-    {
-        $isInSurvey = Yii::app()->is_file(
-            $attachment['url'],
-            Yii::app()->getConfig('uploaddir') . DIRECTORY_SEPARATOR . "surveys" . DIRECTORY_SEPARATOR . $surveyId,
-            false
-        );
-
-        $isInGlobal = Yii::app()->is_file(
-            $attachment['url'],
-            Yii::app()->getConfig('uploaddir') . DIRECTORY_SEPARATOR . "global",
-            false
-        );
-
-        if ($isInSurvey || $isInGlobal) {
-            return true;
-        }
-
-        return false;
     }
 }

--- a/application/core/LimeMailer.php
+++ b/application/core/LimeMailer.php
@@ -902,26 +902,6 @@ class LimeMailer extends \PHPMailer\PHPMailer\PHPMailer
     }
 
     /**
-     * Check if an specific attatchemnt exist
-     * Not needed anymore, SurveyLanuageSetttings return existing file only, keep it for plugin ?
-     * @deprecated 6.16.17
-     * @param string[] attachment info
-     * @return boolean
-     **/
-    private function attachementExists($aAttachment)
-    {
-        $throwError = (Yii::app()->getConfig('debug') && Permission::model()->hasSurveyPermission($this->surveyId, 'surveylocale', 'update'));
-        $SurveyLanguageSetting = SurveyLanguageSetting::model()->findByPk(['surveyls_survey_id' => $this->surveyId, 'surveyls_language' => $this->mailLanguage]);
-        if ($SurveyLanguageSetting->getAttachmentFileExist($aAttachment['url'])) {
-            return true;
-        }
-        if ($throwError) {
-            throw new \CException(sprintf(gT("File not found: %s"), $aAttachment['url']));
-        }
-        return false;
-    }
-
-    /**
      * @inheritdoc
      * Reset the attachementType done to false
      */

--- a/application/core/LimeMailer.php
+++ b/application/core/LimeMailer.php
@@ -1,6 +1,6 @@
 <?php
+
 /**
- * WIP
  * A SubClass of phpMailer adapted for LimeSurvey
  */
 class LimeMailer extends \PHPMailer\PHPMailer\PHPMailer
@@ -887,13 +887,13 @@ class LimeMailer extends \PHPMailer\PHPMailer\PHPMailer
         $attachementType = $this->_aAttachementByType[$this->emailType];
         $oSurveyLanguageSetting = SurveyLanguageSetting::model()->findByPk(array('surveyls_survey_id' => $this->surveyId, 'surveyls_language' => $this->mailLanguage));
         if (!empty($oSurveyLanguageSetting->attachments)) {
-            $aAttachments = unserialize($oSurveyLanguageSetting->attachments);
+            $aAttachments = $oSurveyLanguageSetting->getValidAttachments(true);
             if (!empty($aAttachments[$attachementType])) {
                 if ($this->oToken) {
                     LimeExpressionManager::singleton()->loadTokenInformation($this->surveyId, $this->oToken->token);
                 }
                 foreach ($aAttachments[$attachementType] as $aAttachment) {
-                    if ($this->attachementExists($aAttachment) && LimeExpressionManager::ProcessRelevance($aAttachment['relevance'])) {
+                    if (LimeExpressionManager::ProcessRelevance($aAttachment['relevance'])) {
                         $this->addAttachment($aAttachment['url']);
                     }
                 }
@@ -901,30 +901,23 @@ class LimeMailer extends \PHPMailer\PHPMailer\PHPMailer
         }
     }
 
+    /**
+     * Check if an specific attatchemnt exist
+     * Not needed anymore, SurveyLanuageSetttings return existing file only, keep it for plugin ?
+     * @deprecated 6.16.17
+     * @param string[] attachment info
+     * @return boolean
+     **/
     private function attachementExists($aAttachment)
     {
         $throwError = (Yii::app()->getConfig('debug') && Permission::model()->hasSurveyPermission($this->surveyId, 'surveylocale', 'update'));
-
-        $isInSurvey = Yii::app()->is_file(
-            $aAttachment['url'],
-            Yii::app()->getConfig('uploaddir') . DIRECTORY_SEPARATOR . "surveys" . DIRECTORY_SEPARATOR . $this->surveyId,
-            false
-        );
-
-        $isInGlobal = Yii::app()->is_file(
-            $aAttachment['url'],
-            Yii::app()->getConfig('uploaddir') . DIRECTORY_SEPARATOR . "global",
-            false
-        );
-
-        if ($isInSurvey || $isInGlobal) {
+        $SurveyLanguageSetting = SurveyLanguageSetting::model()->findByPk(['surveyls_survey_id' => $this->surveyId, 'surveyls_language' => $this->mailLanguage]);
+        if ($SurveyLanguageSetting->getAttachmentFileExist($aAttachment['url'])) {
             return true;
         }
-
-        if ($throwError && !($isInSurvey || $isInGlobal)) {
+        if ($throwError) {
             throw new \CException(sprintf(gT("File not found: %s"), $aAttachment['url']));
         }
-
         return false;
     }
 

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -2492,7 +2492,7 @@ function XMLImportResponses($sFullFilePath, $iSurveyID, $aFieldReMap = array())
                                 $results['responses']++;
                             } else {
                                 if (!empty($aInsertData['id'])) {
-                                    $results['warnings'][] = CHtml::errorSummary($response, "<div>" . sprintf(gT("Failed to save response data : response id %s"), 'unescaped') . "</div>");
+                                    $results['warnings'][] = CHtml::errorSummary($response, "<div>" . sprintf(gT("Failed to save response data : response id %s", 'unescaped'), $aInsertData['id']) . "</div>");
                                 } else {
                                     $results['warnings'][] = CHtml::errorSummary($response, "<div>" . gT("Failed to save response data : no response id") . "</div>");
                                 }

--- a/application/helpers/admin/import_helper.php
+++ b/application/helpers/admin/import_helper.php
@@ -1423,9 +1423,17 @@ function XMLImportSurvey($sFullFilePath, $sXMLdata = null, $sNewSurveyName = nul
         // Email attachments are with relative paths on the file, but are currently expected to be saved as absolute.
         // Transforming them from relative paths to absolute paths.
         if (!empty($insertdata['attachments'])) {
+            $attachments = @json_decode($insertdata['attachments'], true);
             // NOTE: Older LSS files have attachments as a serialized array, while newer ones have it as a JSON string.
             // Serialized attachments are not supported anymore.
-            $attachments = json_decode($insertdata['attachments'], true);
+            if (is_null($attachments)) {
+                if (App()->getConfig('allow_unserialize_attachments')) {
+                    $attachments = unserialize($insertdata['attachments'], ['allowed_classes' => false]);
+                    /* If it's a broken unserialize : it's NOT a wrongAttachmentsFormat, it's just invalid */
+                } else {
+                    $wrongAttachmentsFormat = true;
+                }
+            }
             if (!empty($attachments) && is_array($attachments)) {
                 $uploadDir = realpath(Yii::app()->getConfig('uploaddir'));
                 foreach ($attachments as &$template) {
@@ -1442,12 +1450,11 @@ function XMLImportSurvey($sFullFilePath, $sXMLdata = null, $sNewSurveyName = nul
                         $hasOldAttachments = true;
                     }
                 }
-            } elseif (is_null($attachments)) {
-                // JSON decode failed. Most probably the attachments were in the PHP serialization format.
-                $wrongAttachmentsFormat = true;
             }
-            $insertdata['attachments'] = serialize($attachments);
+            /* Set as json only if not empty */
+            $insertdata['attachments'] = !empty($attachments) ? json_encode($attachments) : "";
         }
+
 
         if (isset($insertdata['surveyls_attributecaptions']) && substr($insertdata['surveyls_attributecaptions'], 0, 1) != '{') {
             unset($insertdata['surveyls_attributecaptions']);
@@ -1455,7 +1462,7 @@ function XMLImportSurvey($sFullFilePath, $sXMLdata = null, $sNewSurveyName = nul
         $aColumns = SurveyLanguageSetting::model()->attributes;
         $insertdata = array_intersect_key($insertdata, $aColumns);
 
-        $surveyLanguageSetting = new SurveyLanguageSetting();
+        $surveyLanguageSetting = new SurveyLanguageSetting('import');
         $surveyLanguageSetting->setAttributes($insertdata, false);
         try {
             // Clear alias if it was already in use
@@ -2485,7 +2492,7 @@ function XMLImportResponses($sFullFilePath, $iSurveyID, $aFieldReMap = array())
                                 $results['responses']++;
                             } else {
                                 if (!empty($aInsertData['id'])) {
-                                    $results['warnings'][] = CHtml::errorSummary($response, "<div>" . sprintf(gT("Failed to save response data : response id %s"), 'unescaped'). "</div>");
+                                    $results['warnings'][] = CHtml::errorSummary($response, "<div>" . sprintf(gT("Failed to save response data : response id %s"), 'unescaped') . "</div>");
                                 } else {
                                     $results['warnings'][] = CHtml::errorSummary($response, "<div>" . gT("Failed to save response data : no response id") . "</div>");
                                 }

--- a/application/helpers/common_helper.php
+++ b/application/helpers/common_helper.php
@@ -2653,6 +2653,37 @@ function translateLinks($sType, $iOldSurveyID, $iNewSurveyID, $sString, $isLocal
 }
 
 /**
+* Translate links which are in any email template set to their new counterpart
+* Used only for local file
+*
+* @param mixed $iOldSurveyID Source SurveyId to be replaced
+* @param mixed $iNewSurveyID New SurveyId to be used
+* @param string $sString Link (local path) to be translated
+* @return string
+*/
+function translateJsonLinks($iOldSurveyID, $iNewSurveyID, $sString)
+{
+    if ($sString == '') {
+        return $sString;
+    }
+    /* Avoid regexp injection */
+    $iOldSurveyID = (int) $iOldSurveyID;
+    $iNewSurveyID = (int) $iNewSurveyID;
+    $decodedString = json_decode($sString, true);
+    if (empty($decodedString) || !is_array($decodedString)) {
+        return $sString;
+    }
+    $sPattern = '(([a-z0-9\/\.\-\_:])*(?=(\/upload))\/upload\/surveys\/' . $iOldSurveyID . '\/)';
+    $sReplace = rtrim(App()->getConfig("uploaddir"), "/") . "/surveys/{$iNewSurveyID}/";
+    array_walk_recursive($decodedString, function (&$value) use ($sPattern, $sReplace) {
+        if (is_string($value)) {
+            $value = preg_replace('/' . $sPattern . '/u', $sReplace, $value);
+        }
+    });
+    return json_encode($decodedString);
+}
+
+/**
  * This function creates the old fieldnames for survey import
  *
  * @param mixed $iOldSID The old survey id

--- a/application/helpers/update/updates/Update_500.php
+++ b/application/helpers/update/updates/Update_500.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace LimeSurvey\Helpers\Update;
+
+class Update_500 extends DatabaseUpdateBase
+{
+    public function up()
+    {
+        // Fix serialized attachments, get only needed surveys_languagesettings row
+        $surveyslanguage = \Yii::app()->db->createCommand()
+            ->select(['surveyls_survey_id', 'surveyls_language', 'attachments'])
+            ->from('{{surveys_languagesettings}}')
+            ->where("attachments <> '' AND attachments IS NOT NULL AND attachments <> :emptyarray")
+            ->bindValue(":emptyarray", serialize([]))
+            ->queryAll();
+        foreach ($surveyslanguage as $surveylanguage) {
+            /* Check if it can be a json */
+            if (!empty($surveylanguage['attachments']) && substr($surveylanguage['attachments'], 0, 1) != '{' && substr($surveylanguage['attachments'], 0, 1) != '[') {
+                $sSerialType = getSerialClass($surveylanguage['attachments']);
+                if ($sSerialType == 'array') {
+                    $unserialized = unserialize($surveylanguage['attachments'], ["allowed_classes" => false]);
+                    if (empty($unserialized) || !is_array($unserialized)) {
+                        /* Save broken as empty string */
+                        $newAttachments = "";
+                    } else {
+                        $newAttachments = json_encode($unserialized);
+                        if ($newAttachments === false) {
+                            /* JSON encoding failed, save as empty string */
+                            $newAttachments = "";
+                        }
+                    }
+                } else {
+                    /* All other as empty string */
+                    $newAttachments = "";
+                }
+                $updateCommand = \Yii::app()->db->createCommand();
+                $updateCommand->update(
+                    '{{surveys_languagesettings}}',
+                    array('attachments' => $newAttachments),
+                    'surveyls_survey_id = :sid and surveyls_language = :language',
+                    array(':sid' => $surveylanguage['surveyls_survey_id'], ':language' => $surveylanguage['surveyls_language'])
+                );
+            }
+        }
+    }
+}

--- a/application/helpers/update/updates/Update_500.php
+++ b/application/helpers/update/updates/Update_500.php
@@ -18,7 +18,7 @@ class Update_500 extends DatabaseUpdateBase
             if (!empty($surveylanguage['attachments']) && substr($surveylanguage['attachments'], 0, 1) != '{' && substr($surveylanguage['attachments'], 0, 1) != '[') {
                 $sSerialType = getSerialClass($surveylanguage['attachments']);
                 if ($sSerialType == 'array') {
-                    $unserialized = unserialize($surveylanguage['attachments'], ["allowed_classes" => false]);
+                    $unserialized = @unserialize($surveylanguage['attachments'], ["allowed_classes" => false]);
                     if (empty($unserialized) || !is_array($unserialized)) {
                         /* Save broken as empty string */
                         $newAttachments = "";

--- a/application/models/SurveyLanguageSetting.php
+++ b/application/models/SurveyLanguageSetting.php
@@ -142,7 +142,7 @@ class SurveyLanguageSetting extends LSActiveRecord
             array('surveyls_dateformat', 'numerical', 'integerOnly' => true, 'min' => '1', 'max' => '12', 'allowEmpty' => true),
             array('surveyls_numberformat', 'numerical', 'integerOnly' => true, 'min' => '0', 'max' => '1', 'allowEmpty' => true),
 
-            array('attachments', 'attachmentsInfo'),
+            array('attachments','filter','filter' => array($this, 'filterAttachments')),
         );
     }
 
@@ -192,30 +192,31 @@ class SurveyLanguageSetting extends LSActiveRecord
     }
 
     /**
-     * Defines the customs validation rule attachmentsInfo
+     * Customs filter for rules attachments
      *
-     * @param mixed $attribute
+     * @param string $attribute
+     * @return null|string
+     */
+    public function filterAttachments($attribute)
+    {
+        $attachmentsByType = $this->validateAttachments($attribute, !in_array($this->scenario, ['import', 'copy']));
+        if (empty($attachmentsByType)) {
+            // Save empty attachments as null value
+            return null;
+        }
+        return json_encode($attachmentsByType);
+    }
+
+    /**
+     * Previously broken validatioin rules, replace by filter
+     *
+     * @deprecated 6.16.16
+     * @param string $attribute
+     * @return null|string
      */
     public function attachmentsInfo($attribute)
     {
-        if (empty($this->$attribute)) {
-            return;
-        }
-
-        $value = [];
-        $attachmentsByType = unserialize($this->$attribute);
-        if (is_array($attachmentsByType)) {
-            foreach ($attachmentsByType as $type => $attachments) {
-                if (is_array($attachments)) {
-                    foreach ($attachments as $key => $attachment) {
-                        if (isset($attachment['url']) && isset($attachment['size']) && isset($attachment['relevance'])) {
-                            $value[$type][$key] = $attachment;
-                        }
-                    }
-                }
-            }
-        }
-        return serialize($value);
+        return $this->filterAttachments($this->$attribute);
     }
 
     /**
@@ -337,14 +338,12 @@ class SurveyLanguageSetting extends LSActiveRecord
 
     /**
      * Returns the array of email attachments data without exposing sensitive paths
-     * @return array<string,array<string,mixed>>
+     * Used for export_helper
+     * @return string[][][] : array of attachments array by template, sample by key [template][][url,size,relevance]
      */
     public function getAttachmentsData()
     {
-        if (empty($this->attachments)) {
-            return [];
-        }
-        $attachments = unserialize($this->attachments);
+        $attachments = $this->getValidAttachments(false); // Do not check when export
         if (is_array($attachments)) {
             $uploadDir = realpath(Yii::app()->getConfig('uploaddir'));
             foreach ($attachments as &$template) {
@@ -358,5 +357,80 @@ class SurveyLanguageSetting extends LSActiveRecord
             }
         }
         return $attachments;
+    }
+
+    /**
+     * Get valid attachements in array
+     * @param boolean $exist check if file exist in a valid directory
+     * @return string[][][] : array of attachments array by template, sample by key [template][][url,size,relevance]
+     **/
+    public function getValidAttachments($exist = true)
+    {
+        return $this->validateAttachments($this->attachments, $exist);
+    }
+
+    /**
+     * Get valid attachements in array
+     * @param string $attachement the attahcment string to be filtered
+     * @param boolean $exist check if file exist in a valid directory
+     * @return string[][][] : array of attachments array by template, sample by key [template][][url,size,relevance]
+     **/
+    public function validateAttachments($string, $exist = true)
+    {
+        if (empty($string) || !is_string($string)) {
+            return [];
+        }
+        $attachments = json_decode($string, 1);
+        if (empty($attachments) || !is_array($attachments)) {
+            return [];
+        }
+        $validAttachements = [];
+        foreach ($attachments as $template => $templateAttachements) {
+            foreach ($templateAttachements as $attachment) {
+                if (!isset($attachment['url'])) {
+                    continue;
+                }
+                if ($exist && !$this->getAttachmentFileExist($attachment['url'])) {
+                    continue;
+                }
+                if ($exist) {
+                    $attachment['size'] = filesize($attachment['url']);
+                }
+                $validAttachements[$template][] = [
+                    'url' => $attachment['url'],
+                    'size' => $attachment['size'] ?? '0',
+                    'relevance' => $attachment['relevance'] ?? '1',
+                ];
+            }
+        }
+        return $validAttachements;
+    }
+
+    /**
+     * Check if a file for attachment exist
+     * @param string $file
+     * @return boolean
+     */
+    public function getAttachmentFileExist($file)
+    {
+        if (
+            App()->is_file(
+                realpath($file),
+                realpath(App()->getConfig('uploaddir') . DIRECTORY_SEPARATOR . "surveys" . DIRECTORY_SEPARATOR . $this->surveyls_survey_id),
+                false
+            )
+        ) {
+            return true;
+        }
+        if (
+            App()->is_file(
+                realpath($file),
+                realpath(App()->getConfig('uploaddir') . DIRECTORY_SEPARATOR . "global"),
+                false
+            )
+        ) {
+            return true;
+        }
+        return false;
     }
 }

--- a/docs/release_notes.txt
+++ b/docs/release_notes.txt
@@ -35,19 +35,19 @@ Thank you to everyone who helped with this new release!
 CHANGE LOG
 ------------------------------------------------------
 Changes from 5.6.85 (SondagesPro) to 5.6.86 (SondagesPro) February 25, 2026
-New feature #16619: Allow get_uploaded_files() Remote function by response ID
-Fixed issue #20337: Cannot add a User Group to Survey Permissions unless at least one User is already added
-Fixed issue #20391: Spinner when trying to save survey settings
-Fixed issue #20424: [security] SQL Injection in RemoteControl API
+- New feature #16619: Allow get_uploaded_files() Remote function by response ID
+- Fixed issue #20337: Cannot add a User Group to Survey Permissions unless at least one User is already added
+- Fixed issue #20391: Spinner when trying to save survey settings
+- Fixed issue #20424: [security] SQL Injection in RemoteControl API
 
 Changes from 5.6.84 (SondagesPro) to 5.6.85 (SondagesPro) January 26, 2026
-Fixed issue [security] #20366: TwoFactorAdminLogin should create secret with minimum 128 bits
-Fixed issue [security] #20390: Prevent XSS phishing by navigating browser tabs
+- Fixed issue [security] #20366: TwoFactorAdminLogin should create secret with minimum 128 bits
+- Fixed issue [security] #20390: Prevent XSS phishing by navigating browser tabs
 
 Changes from 5.6.83 (SondagesPro) to 5.6.84 (SondagesPro) December 18, 2025
-Fixed issue [security] #20388: User with "update surveys" can delete surveys
-Fixed issue [security] Update to twig 1.44.8
-Fixed issue [security] #20384: XSS Vulnerability in question editor
+- Fixed issue [security] #20388: User with "update surveys" can delete surveys
+- Fixed issue [security] Update to twig 1.44.8
+- Fixed issue [security] #20384: XSS Vulnerability in question editor
 
 Changes from 5.6.82 (SondagesPro) to 5.6.83 (SondagesPro) November 24, 2025
 - Fixed issue : Fix test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic link translation when copying surveys to update attachment URLs.

* **Bug Fixes**
  * Improved attachment handling and validation across email templates, imports, and sending.
  * Safer conversion of legacy attachment formats during import/migration.

* **Configuration**
  * New config option to allow legacy unserialized attachments (disabled by default).

* **Documentation**
  * Minor release notes formatting tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->